### PR TITLE
Add letter_opener_web gem for development environment

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,7 @@ end
 
 group :development do
   gem "error_highlight", ">= 0.4.0", platforms: [:ruby]
+  gem "letter_opener_web"
   gem "rubocop", "~> 1.59"
   gem "web-console"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,6 +92,8 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    childprocess (5.1.0)
+      logger (~> 1.5)
     concurrent-ruby (1.3.3)
     connection_pool (2.4.1)
     crass (1.0.6)
@@ -141,6 +143,16 @@ GEM
       railties (>= 6.0.0)
     json (2.7.2)
     language_server-protocol (3.17.0.3)
+    launchy (3.0.1)
+      addressable (~> 2.8)
+      childprocess (~> 5.0)
+    letter_opener (1.10.0)
+      launchy (>= 2.2, < 4)
+    letter_opener_web (3.0.0)
+      actionmailer (>= 6.1)
+      letter_opener (~> 1.9)
+      railties (>= 6.1)
+      rexml
     logger (1.6.0)
     lograge (0.14.0)
       actionpack (>= 4)
@@ -357,6 +369,7 @@ DEPENDENCIES
   foreman (~> 0.88.1)
   jbuilder
   jsbundling-rails
+  letter_opener_web
   lograge (~> 0.14.0)
   pg (~> 1.5, >= 1.5.8)
   prawn (~> 2.5)

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -71,4 +71,6 @@ Rails.application.configure do
   config.web_console.allowed_ips = ["0.0.0.0/0"]
 
   config.active_job.queue_adapter = :solid_queue
+
+  config.action_mailer.delivery_method = :letter_opener_web
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
+  mount LetterOpenerWeb::Engine, at: "/letter_opener" if Rails.env.development?
+
   root "document#show"
   resource :document, only: [:show], controller: "document"
   get "up" => "rails/health#show", as: :rails_health_check


### PR DESCRIPTION
This pull request introduces the `letter_opener_web` gem to improve email debugging in the development environment. The most important changes include adding the gem to the `Gemfile`, configuring the mailer delivery method, and updating the routes to mount the `LetterOpenerWeb::Engine`.

The web interface is then accessible here: http://localhost:3000/letter_opener/